### PR TITLE
Add CI workflow to build and test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: wombat CI
+
+on:
+  pull_request:
+    branches:    
+      - 'main'
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  Build-and-Test:
+    runs-on: self-hosted
+    container: alsora/wombat-base:latest
+    env:
+      COLCON_HOME: ${{ github.workspace }}/.colcon
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Build wombat
+        run: |
+          source /workspaces/ros2_galactic/install/setup.sh \
+          && colcon build --symlink-install --event-handlers=console_cohesion+
+      - name: Run unit-tests
+        run: |
+          source /workspaces/ros2_galactic/install/setup.sh \
+          && colcon test --mixin no-linters --return-code-on-test-failure --event-handlers=console_cohesion+
+      - name: Run linters
+        run: |
+          source /workspaces/ros2_galactic/install/setup.sh \
+          && colcon test --mixin linters --return-code-on-test-failure --event-handlers=console_cohesion+


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

Add a github action that runs on pull requests and whenever main is updated.
This action uses the `wombat-base` docker image, builds the code and run all unit-tests (including linters).

## Tests

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] The code is commented in public APIs and hard-to-understand areas
- [x] Tests and linters don't produce errors (`colcon test --mixin all`)
