### PR TITLE
modify docker run.sh to avoid errors when running headless

### DIFF
--- a/utils/dev-environment/run.sh
+++ b/utils/dev-environment/run.sh
@@ -27,16 +27,25 @@ docker build \
   --tag wombat-dev \
   $THIS_DIR
 
-# Make sure XAUTH exists
-XSOCK=/tmp/.X11-unix
-XAUTH=/tmp/.docker.xauth
-touch ${XAUTH}
-xauth nlist ${DISPLAY} | sed -e 's/^..../ffff/' | xauth -f ${XAUTH} nmerge -
+# Check if we have display
+DISPLAY_ARGS=""
+if [ ! -z ${DISPLAY} ]; then
+  # Make sure XAUTH exists
+  XSOCK=/tmp/.X11-unix
+  XAUTH=/tmp/.docker.xauth
+  touch ${XAUTH}
+  xauth nlist ${DISPLAY} | sed -e 's/^..../ffff/' | xauth -f ${XAUTH} nmerge -
+
+  DISPLAY_ENV="--env DISPLAY=${DISPLAY} --env XAUTHORITY=${XAUTH}"
+  DISPLAY_VOLUMES="--volume=${XSOCK}:${XSOCK}:rw --volume=${XAUTH}:${XAUTH}:rw"
+
+  DISPLAY_ARGS="${DISPLAY_ENV} ${DISPLAY_VOLUMES}"
+fi
 
 # Check if we have GPUs
-GPU_FLAG=""
+GPU_ARGS=""
 if type "nvidia-container-cli" &> /dev/null && nvidia-container-cli info &> /dev/null; then 
-  GPU_FLAG="--gpus=all"
+  GPU_ARGS="--gpus=all"
 fi
 
 # Define some useful directory names
@@ -46,14 +55,11 @@ DOCKER_WOMBAT_WS=${DOCKER_HOME}/wombat
 
 # Run the developer's dockerfile
 docker run -it --rm \
-  --env="DISPLAY=${DISPLAY}" \
-  --env="XAUTHORITY=${XAUTH}" \
-  ${GPU_FLAG} \
+  ${DISPLAY_ARGS} \
+  ${GPU_ARGS} \
   --network=host \
   --privileged \
   --user=${UID}:${UID} \
-  --volume=${XSOCK}:${XSOCK}:rw \
-  --volume=${XAUTH}:${XAUTH}:rw \
   --volume=${HOME}:${DOCKER_HOME}/host-home:rw \
   --volume=${HOME}/.gitconfig:${DOCKER_HOME}/.gitconfig:ro \
   --volume=${HOME}/.ssh:${DOCKER_HOME}/.ssh:ro \


### PR DESCRIPTION
## Description

The `run.sh` script was assuming that a display is always available.
This was resulting in confusing warnings when running in headless mode.
Added a check for the `$DISPLAY` env variable to decide whether to forward display to docker or not.

## Tests

Tested with and without display.

## Checklist

- [x] I have performed a self-review of my own code
- [x] The code is commented in public APIs and hard-to-understand areas
- [x] Eventual new algorithms, concepts or workflows are documented in the liar-docs
- [x] Tests and linters don't produce errors (`colcon test --mixin all`)
