### PR TITLE
restore --event-handlers=console_cohesion+ argument in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,14 @@ jobs:
         run: |
           source /opt/ros/rolling/setup.sh \
           && source /opt/ros2_workspace_base/install/local_setup.sh \
-          && VERBOSE=1 colcon build --symlink-install
+          && VERBOSE=1 colcon build --symlink-install --event-handlers=console_cohesion+
       - name: Run unit-tests
         run: |
           source /opt/ros/rolling/setup.sh \
           && source /opt/ros2_workspace_base/install/local_setup.sh \
-          && VERBOSE=1 colcon test --mixin no-linters --return-code-on-test-failure
+          && VERBOSE=1 colcon test --mixin no-linters --return-code-on-test-failure --event-handlers=console_cohesion+
       - name: Run linters
         run: |
           source /opt/ros/rolling/setup.sh \
           && source /opt/ros2_workspace_base/install/local_setup.sh \
-          && VERBOSE=1 colcon test --mixin linters --return-code-on-test-failure
+          && VERBOSE=1 colcon test --mixin linters --return-code-on-test-failure --event-handlers=console_cohesion+


### PR DESCRIPTION
this is needed to have a fully verbose log

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

This argument was removed in a previous PR, but it's actually needed.
In particular it's needed to be able to see test failures in the CI log.

