### PR TITLE
bump dev-environment VERSION to 0.1.1 adding support for ccache

### DIFF
--- a/utils/dev-environment/VERSION
+++ b/utils/dev-environment/VERSION
@@ -1,1 +1,1 @@
-alsora/wombat-base-nvidia:0.1.0
+alsora/wombat-base-nvidia:0.1.1


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

bump `dev-environment` to new version which includes `ccache`.
cleanup `run.sh` script