### PR TITLE
add .dockerignore file in devdocker environment

### DIFF
--- a/utils/dev-environment/.dockerignore
+++ b/utils/dev-environment/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore everything
+*

--- a/utils/dev-environment/setup-docker.sh
+++ b/utils/dev-environment/setup-docker.sh
@@ -120,16 +120,14 @@ fi
 if [ ! -d ${USER_DEVDOCKER} ]; then
   mkdir ${USER_DEVDOCKER}
 fi
-# Symbolic link the run script
-RUN_SCRIPT="run.sh"
-RUN_SCRIPT_LINK=${USER_DEVDOCKER}/${RUN_SCRIPT}
-if [ -e ${RUN_SCRIPT_LINK} ] && [ ! -L ${RUN_SCRIPT_LINK} ]; then
-  rm -rf ${RUN_SCRIPT_LINK}
-fi
-if [ ! -L ${RUN_SCRIPT_LINK} ]; then
-  ln -s ${THIS_DIR}/${RUN_SCRIPT} ${RUN_SCRIPT_LINK}
-  chmod +x ${RUN_SCRIPT_LINK}
-fi
+
+# Symbolic link files to the user devdocker directory
+for filename in "run.sh" ".dockerignore"; do
+  ORIGINAL_PATH=${THIS_DIR}/${filename}
+  SYMLINKED_PATH=${USER_DEVDOCKER}/${filename}
+  create_symlink ${ORIGINAL_PATH} ${SYMLINKED_PATH}
+done
+
 # Create the user dockerfile
 USER_DOCKERFILE=${USER_DEVDOCKER}/Dockerfile
 FROM_IMAGE_CMD="FROM ${DEVELOPER_IMAGE}"

--- a/utils/dev-environment/utils.sh
+++ b/utils/dev-environment/utils.sh
@@ -9,7 +9,34 @@ is_ubuntu_host() {
   echo ${IS_UBUNTU_HOST}
 }
 
+# Checks if the first version argument is smaller or equal than the second one
+# NOTE: this utility is Linux-only!
+# From https://stackoverflow.com/a/4024263
 versioncmp() {
-  # From https://stackoverflow.com/a/4024263
   [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+# Create a symlink to the first path at the destination path.
+# If ANYTHING already exists at the destination path, it will be destroyed.
+create_symlink() {
+  ORIGINAL_PATH=$1
+  SYMLINKED_PATH=$2
+
+  if [ ! -e ${ORIGINAL_FILE} ]; then
+    echo "The path to symlink does not exist: ${ORIGINAL_PATH}"
+    exit 1
+  fi
+
+  # If the symlinked path already exists
+  if [ -e ${SYMLINKED_PATH} ]; then
+    # If it's not a link or if it does not point to the expected path, remove it
+    if [ ! -L ${SYMLINKED_PATH} ] || [ ! "${SYMLINKED_PATH}" -ef "${ORIGINAL_PATH}" ]; then
+      rm -rf ${SYMLINKED_PATH}
+    fi
+  fi
+
+  # If the symlink path does not exist, create it
+  if [ ! -L ${SYMLINKED_PATH} ]; then
+    ln -s ${ORIGINAL_PATH} ${SYMLINKED_PATH}
+  fi
 }


### PR DESCRIPTION

## Description

add .dockerignore file in devdocker environment
after the introduction of ccache, the devdocker directory may grow very big

## Tests

start docker environment and verify that the various files from `.devdocker` directory were not added as part of the docker build context
