### PR TITLE
fix variable name for dev environment bash history file

### DIFF
--- a/utils/dev-environment/run.sh
+++ b/utils/dev-environment/run.sh
@@ -52,8 +52,8 @@ DOCKER_WOMBAT_DIR=${DOCKER_HOME}/wombat
 # Persistent bash history file
 BASH_HISTORY_FILE=${THIS_DIR}/.bash_history
 DOCKER_BASH_HISTORY_FILE=${DOCKER_HOME}/.bash_history
-if [ ! -f ${BASH_HISTORY_FILE_PATH} ]; then
-  touch ${BASH_HISTORY_FILE_PATH}
+if [ ! -f ${BASH_HISTORY_FILE} ]; then
+  touch ${BASH_HISTORY_FILE}
 fi
 BASH_HISTORY_ARGS="--volume=${BASH_HISTORY_FILE}:${DOCKER_BASH_HISTORY_FILE}:rw"
 


### PR DESCRIPTION
## Description

Use correct variable name in `run.sh` script (there was no variable named `BASH_HISTORY_FILE_PATH`).

We need to mount as a volume a file.
If the file does not exist yet, we first create it empty with `touch`.
The wrong variable name was resulting in the file being never created.

Without the file, when mounting the volume docker would have automatically created a directory there (rather than a file as expected)

## Tests

Verify that a file is correctly created.
